### PR TITLE
Add audioop-lts to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-socketio
 requests
 aiosqlite
 docker
+audioop-lts


### PR DESCRIPTION
Needed for bot.py to run without docker without crashing.