### PR TITLE
Storage Size Fix

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -318,7 +318,7 @@ class RommBot(discord.Bot):
                     "Saves": raw_data.get('SAVES', 0),
                     "States": raw_data.get('STATES', 0),
                     "Screenshots": raw_data.get('SCREENSHOTS', 0),
-                    "Storage Size": self.bytes_to_tb(raw_data.get('FILESIZE', 0))
+                    "Storage Size": self.bytes_to_tb(raw_data.get('TOTAL_FILESIZE_BYTES', 0))
                 }
         
             elif data_type == 'platforms':

--- a/cogs/search.py
+++ b/cogs/search.py
@@ -45,7 +45,7 @@ class ROM_View(discord.ui.View):
             file_name = rom.get('file_name', 'Unknown filename')
             
             # Get correct size for dropdown
-            size_bytes = rom.get('file_size_bytes', 0)
+            size_bytes = rom.get('fs_size_bytes', 0)
             if not size_bytes and rom.get('files'):
                 # For multi-file ROMs, sum the sizes
                 size_bytes = sum(f.get('size_bytes', 0) for f in rom['files'])

--- a/cogs/search.py
+++ b/cogs/search.py
@@ -45,7 +45,7 @@ class ROM_View(discord.ui.View):
             file_name = rom.get('file_name', 'Unknown filename')
             
             # Get correct size for dropdown
-            size_bytes = rom.get('fs_size_bytes', 0)
+            size_bytes = rom.get('file_size_bytes', 0)
             if not size_bytes and rom.get('files'):
                 # For multi-file ROMs, sum the sizes
                 size_bytes = sum(f.get('size_bytes', 0) for f in rom['files'])


### PR DESCRIPTION
At some point in time, RomM has updated the output of /api/stats to change the output from "FILESIZE" to "TOTAL_FILESIZE_BYTES". 

This suggested change will ensure that the proper output is collected for the Storage Size in discord both in the "ROM Server Stats" and the /stats discord command.