### PR TITLE
fix: use Tuple[...] for Python 3.8 typing compatibility in search cog

### DIFF
--- a/cogs/search.py
+++ b/cogs/search.py
@@ -167,7 +167,7 @@ class ROM_View(discord.ui.View):
             logger.error(f"Error downloading cover image: {e}")
             return None
     
-    async def create_rom_embed(self, rom_data: Dict) -> tuple[discord.Embed, Optional[discord.File]]:
+    async def create_rom_embed(self, rom_data: Dict) -> Tuple[discord.Embed, Optional[discord.File]]:
         try:
             # When creating the download URL in the embed
             raw_file_name = rom_data.get('fs_name', 'unknown_file')


### PR DESCRIPTION
This PR fixes a compatibility issue with Python 3.8 in search.py. https://github.com/idio-sync/romm-comm/issues/25

Changes the return type annotation in create_rom_embed from tuple[...] to Tuple[...] (from the typing module), which is required for Python 3.8 compatibility.

This resolves a TypeError: 'type' object is not subscriptable that prevented the cogs.search and cogs.requests cogs from loading on Python 3.8.
Testing:

Verified that both cogs now load successfully on Python 3.8.
No functional changes to bot behavior.


<img width="534" height="269" alt="image" src="https://github.com/user-attachments/assets/fcd0d868-700a-4024-aadf-10a3e8d86d52" />

<img width="429" height="708" alt="image" src="https://github.com/user-attachments/assets/2b35e022-e2cd-4a2a-9a2b-ea93122dd078" />

