### PR TITLE
Add support for 'cheat' subfolder category with card suit icon

### DIFF
--- a/cogs/search.py
+++ b/cogs/search.py
@@ -113,7 +113,7 @@ class ROM_View(discord.ui.View):
         if not file_path:
             return None
 
-        known_subfolders = ['hack', 'dlc', 'manual', 'mod', 'patch', 'update', 'demo', 'translation', 'prototype']
+        known_subfolders = ['hack', 'dlc', 'manual', 'mod', 'patch', 'update', 'demo', 'translation', 'prototype', 'cheat']
         path_parts = file_path.split('/')
         for part in path_parts:  # include all parts
             if part.lower() in known_subfolders:
@@ -133,6 +133,7 @@ class ROM_View(discord.ui.View):
             'demo': '🎮',
             'translation': '🌐',
             'prototype': '🔬',
+            'cheat': '🃏',
             None: '📄'  # Default for main/root files
         }
         return icons.get(subfolder, '📁')


### PR DESCRIPTION
## Summary
This PR adds support for a new 'cheat' subfolder category to the file search functionality, allowing files in cheat-related directories to be properly categorized and displayed with a distinctive icon.

## Key Changes
- Added `'cheat'` to the `known_subfolders` list in `get_file_subfolder()` function to recognize cheat-related file paths
- Added cheat folder icon mapping (`'cheat': '🃏'`) in `get_subfolder_icon()` function to display the playing card suit emoji for cheat files

## Implementation Details
The changes follow the existing pattern for subfolder categorization:
- The 'cheat' category is now recognized alongside other special categories (hack, dlc, manual, mod, patch, update, demo, translation, prototype)
- Uses the 🃏 (playing card suit) emoji as the visual indicator for cheat files, which is thematically appropriate and visually distinct from other categories

https://claude.ai/code/session_018F8ZDPDRPZDgmvtGxeBJVs